### PR TITLE
Rename the output_types argument into output_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ import transformers
 from pydantic import BaseModel, Field
 from langextract_outlines import OutlinesProvider
 
-
 # Define your extraction prompt and examples
 prompt = "Extract characters and emotions from the text."
 examples = [
     lx.data.ExampleData(
-        text="Romeo gazed longingly at Juliet.",
+        "Romeo gazed longingly at Juliet.",
         extractions=[
             lx.data.Extraction(
                 extraction_class="character",
@@ -81,12 +80,13 @@ outlines_provider = OutlinesProvider(
     output_type=output_type,
     backend="outlines_core",
     temperature=0.5,
-    repetition_penalty=1
+    repetition_penalty=1,
+    max_new_tokens=100,
 )
 
 # Run extraction
 result = lx.extract(
-    text="Juliet smiled brightly at the stars.",
+    "Juliet smiled brightly at the stars.",
     prompt_description=prompt,
     examples=examples,
     model=outlines_provider,

--- a/langextract_outlines/provider.py
+++ b/langextract_outlines/provider.py
@@ -26,7 +26,7 @@ class OutlinesProvider(inference.BaseLanguageModel):
     def __init__(
         self,
         outlines_model: Model | AsyncModel,
-        output_types: Optional[OutputTypes] = None,
+        output_type: Optional[OutputTypes] = None,
         backend: Optional[str] = None,
         **inference_kwargs,
     ) -> None:
@@ -35,7 +35,7 @@ class OutlinesProvider(inference.BaseLanguageModel):
         ----------
         outlines_model:
             The Outlines Model instance to use for inference
-        output_types:
+        output_type:
             A list of Pydantic models that correspond to the extraction classes
             used in the examples. The value provided will be turned into a
             Pydantic model that that will be used by Outlines to constrain the
@@ -48,10 +48,10 @@ class OutlinesProvider(inference.BaseLanguageModel):
         """
         super().__init__(schema.Constraint(constraint_type=schema.ConstraintType.NONE))
 
-        formatted_output_types = _format_output_type(output_types)
+        formatted_output_type = _format_output_type(output_type)
         self._generator = Generator(
             outlines_model,
-            formatted_output_types,
+            formatted_output_type,
             backend,
         )
         self._inference_kwargs = inference_kwargs or {}
@@ -90,7 +90,7 @@ class OutlinesProvider(inference.BaseLanguageModel):
 
 
 def _format_output_type(
-    user_output_types: Optional[OutputTypes] = None,
+    user_output_type: Optional[OutputTypes] = None,
 ) -> Optional[type[BaseModel]]:
     """Turn the user's list of pydantic models into the output type
     expected by LE.
@@ -101,7 +101,7 @@ def _format_output_type(
 
     Parameters
     ----------
-    user_output_types:
+    user_output_type:
         A list of Pydantic models that correspond to the extraction classes
         used in the examples.
 
@@ -114,20 +114,20 @@ def _format_output_type(
         extraction classes.
 
     """
-    if not user_output_types:
+    if not user_output_type:
         return None
 
-    if not isinstance(user_output_types, list) or not all(
-        is_pydantic_model(item) for item in user_output_types
+    if not isinstance(user_output_type, list) or not all(
+        is_pydantic_model(item) for item in user_output_type
     ):
         raise ValueError(
-            "The `output_types` parameter must be a list of Pydantic "
-            "models. Got: " + str(user_output_types)
+            "The `output_type` parameter must be a list of Pydantic "
+            "models. Got: " + str(user_output_type)
         )
 
     base_models = []
 
-    for user_output_type in user_output_types:
+    for user_output_type in user_output_type:
         # Each extraction class must have a name and attributes
         # in a field called `<name>_attributes`
         class_name = user_output_type.__name__

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -34,8 +34,8 @@ class Emotion(BaseModel):
 
 def test_format_output_type():
     # Single class
-    output_types = [Character]
-    formatted_output_type = _format_output_type(output_types)
+    output_type = [Character]
+    formatted_output_type = _format_output_type(output_type)
 
     assert is_pydantic_model(formatted_output_type)
     extractions = formatted_output_type.model_fields["extractions"].annotation
@@ -44,8 +44,8 @@ def test_format_output_type():
     assert character.model_fields["character_attributes"].annotation == Character
 
     # Multiple classes
-    output_types = [Character, Emotion]
-    formatted_output_type = _format_output_type(output_types)
+    output_type = [Character, Emotion]
+    formatted_output_type = _format_output_type(output_type)
 
     assert is_pydantic_model(formatted_output_type)
     extractions = formatted_output_type.model_fields["extractions"].annotation


### PR DESCRIPTION
The vocabulary in the library was inconsistent and there was a bug in the example in the README as a result. I propose we use `output_type` as it's the name of the argument in `outlines`.